### PR TITLE
Testing for all 6 test cases: POSITIVE

### DIFF
--- a/test/user.test.js
+++ b/test/user.test.js
@@ -23,7 +23,9 @@ contract('user', (accounts) => {
  
     it('Should be able to add a user', async () => {
 
-        const userToken = UserInstance.users[0xa0daa9c951e695deea607a98376a83e7c3a23a14];
+        const userAddress = "0xa0daa9c951e695deea607a98376a83e7c3a23a14";
+
+        const userToken = await UserInstance.users.call(userAddress);
 
 
         const result = {


### PR DESCRIPTION
The issue seems to be that you can't access a struct written in solidity into javascript. But making the struct public gives it a default getter function which we can use to call(access) the struct at any particular user_address.

Used the solidity generated getter function to access the struct deleting the previously used method of simply referencing the mapping

Fixes #1 